### PR TITLE
Add Verbose Option and Fix README Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Conversion to Python 3
 This code is inspired by [GitLab Community Edition (CE) 13.10.3 - User Enumeration
-](https://www.exploit-db.com/exploits/49821) in Python3 for [Academy](http://academy.hackthebox.com/) for Module "Attacking Commoon Applications" and section "Attacking GitLab".
+](https://www.exploit-db.com/exploits/49821) in Python3 for [Academy](http://academy.hackthebox.com/) for Module "Attacking Common Applications" and section "Attacking GitLab".
 
 The original code was written in Bash. 
 

--- a/gitlab_userenum.py
+++ b/gitlab_userenum.py
@@ -7,6 +7,7 @@ def main():
     parser = argparse.ArgumentParser(description='GitLab User Enumeration')
     parser.add_argument('--url', '-u', type=str, required=True, help='The URL of the GitLab\'s instance')
     parser.add_argument('--wordlist', '-w', type=str, required=True, help='Path to the username wordlist')
+    parser.add_argument('-v', action='store_true', help='Enable verbose mode')
     args = parser.parse_args()
 
     print('GitLab User Enumeration in python')
@@ -14,6 +15,8 @@ def main():
     with open(args.wordlist, 'r') as f:
         for line in f:
             username = line.strip()
+            if args.v:
+                print(f'Trying username {line[:-1]}...')
             http_code = requests.head(f'{args.url}/{username}').status_code
             if http_code == 200:
                 print(f'[+] The username {username} exists!')


### PR DESCRIPTION
I came across this script while doing the GitLab section of the Common Applications module in the Hack The Box Academy and found that it was difficult to tell how far through the wordlist the script was, or if it was even doing anything at all. I also noticed a minor typo in the `README`. This PR addresses both of those issues. 

I added an optional `-v` argument that will print out which username the script is currently trying. This will provide constant feedback to the user indicating that the script is progressing through the wordlist, and that the application is responding. I used string splicing on the `line` variable to remove the new line characters that made the output look strange (this only affects the output text and does not actually influence the `line` variable in any way). If the user decides to watch the script execute with verbose mode on, the output that indicates a valid username will stand out since it starts with a `[+]`. If they decide to redirect the output to a file, they could easily use `grep` to find the lines that contain the word `exists`. 

I did notice at the time of writing this PR that I forgot to update the `Usage` section of the README to include the new `-v` option. I can add that in if desired. 